### PR TITLE
Fix bad link

### DIFF
--- a/docs/software/overview.md
+++ b/docs/software/overview.md
@@ -18,7 +18,7 @@ and accessible via the module system.
 
 ## Conflicting modules
 
-- [Conflicting modules](modules_conflicts.md]
+- [Conflicting modules](../cluster_guides/module_conflicts.md)
 
 ## Reach the Bioinformatics tools
 


### PR DESCRIPTION
Shouldn't the markdown or link checker have caught this?

Also not sure if "Conflicting modules" reallys is among the first thing we have to show about Software. But a working link is at least better than a broken one! :-)