### PR TITLE
Fix mkdocs warnings

### DIFF
--- a/docs/cluster_guides/start_interactive_node.md
+++ b/docs/cluster_guides/start_interactive_node.md
@@ -12,7 +12,7 @@ tags:
 Below we describe the general ideas of using an interactive node:
 
 - [the types of nodes](#types-of-nodes)
-- [When to use an interactive node](#when-to-use-an-interactive node)
+- [When to use an interactive node](#when-to-use-an-interactive-node)
 
 To start an interactive node on specific cluster:
 

--- a/docs/software/beast2.md
+++ b/docs/software/beast2.md
@@ -248,9 +248,9 @@ beast -beagle_info
 This problem seems to be related to not having a proper X server installed.
 In this case, [SSH X forwarding](ssh_x_forwarding.md) works to the extent
 that SSH is able to show [`xeyes`](../software/xeyes.md), yet fails to show BEAUti.
-Also, [using the remote desktop via a ThinLinc client](../getting_started/login_rackham.md#remote-desktop-via-a-ThinLinc client) fails.
+Also, [using the remote desktop via a ThinLinc client](../getting_started/login_rackham_remote_desktop_local_thinlinc_client.md) fails.
 
-A solution may be to [use the remote desktop via the web](../getting_started/login_rackham.md#remote-desktop-via-the-web)
+A solution may be to [use the remote desktop via the web](../getting_started/login_rackham_remote_desktop_website.md)
 
 ???- question "How does that look like?"
 

--- a/docs/software/install.md
+++ b/docs/software/install.md
@@ -142,7 +142,7 @@ container.
 - You may have your own code that you want to run on UPPMAX.
 - [Guide for compiling **serial** programs](compiling_serial.md)
 - [Guide for compiling **parallel** programs](compiling_parallel.md)
-    - [Available **combinations** of compilers and parallel libraries](compiling_parallel.md#overview-of-available-compilers-from-gcc-and-intel-and-compatible-mpi-libraries)
+    - [Available **combinations** of compilers and parallel libraries](parallel_comb.md)
 - [User guide for debuggers](../software/debuggers.md)
 - [User guide for profilers](../software/profilers.md)
 

--- a/docs/software/jobstats.md
+++ b/docs/software/jobstats.md
@@ -8,7 +8,7 @@
 for jobs submitted to the [Slurm](../cluster_guides/slurm.md) job queue.
 
 At this page, it is described:
-
+<!-- markdownlint-disable-next-line MD051 -->
 - [`jobstats --plot`](#jobstats-plot): How to use is `jobstats --plot` to see resource use in a graphical plot
 - [Efficient use](#efficient-use): How to use your resources efficiently
 - [Examples](#examples): Examples of ineffective resource use plots

--- a/docs/software/jobstats.md
+++ b/docs/software/jobstats.md
@@ -9,7 +9,7 @@ for jobs submitted to the [Slurm](../cluster_guides/slurm.md) job queue.
 
 At this page, it is described:
 
-- [`jobstats --plot`](#jobstats---plot): How to use is `jobstats --plot` to see resource use in a graphical plot
+- [`jobstats --plot`](#jobstats-plot): How to use is `jobstats --plot` to see resource use in a graphical plot
 - [Efficient use](#efficient-use): How to use your resources efficiently
 - [Examples](#examples): Examples of ineffective resource use plots
 - Other `jobstats` functionality

--- a/docs/software/python.md
+++ b/docs/software/python.md
@@ -5,7 +5,7 @@
 Welcome to the UPPMAX Python user guide.
 
 We describe [what Python is](#what-is-python)
-and that there are [multiple Python versions](Python versions).
+and that there are [multiple Python versions](#python-versions).
 
 Then, we show how to [load Python](#loading-python)
 and to [load Python packages](#loading-python-packages)

--- a/docs/software/python_venv.md
+++ b/docs/software/python_venv.md
@@ -32,7 +32,7 @@ which has these steps:
 The first step is described at
 ['Loading Python'](../software/python.md#loading-python)
 and
-['Loading Python package modules'](../software/python.md#loading-python-modules).
+['Loading Python package modules'](../software/python.md#loading-python-package-modules).
 
 ???- question "Just show me how to do this"
 
@@ -42,7 +42,7 @@ and
     module load python/3.11.8
     ```
 
-    Here is how to [load a Python package module](../software/python.md#loading-python-modules):
+    Here is how to [load a Python package module](../software/python.md#loading-python-package-modules):
 
     ```bash
     module load python_ML_packages/3.11.8-cpu

--- a/docs/software/r.md
+++ b/docs/software/r.md
@@ -291,7 +291,7 @@ A large number of R packages are available as part of the R_packages/3.3.0 modul
 
 [The Carpentries](https://carpentries.org/) teaches basic lab skills for research computing, such as:
 
-- [Programming with R](swcarpentry.github.io/r-novice-inflammation/)
+- [Programming with R](https://swcarpentry.github.io/r-novice-inflammation/)
 - [R for reproducible scientific analysis](https://swcarpentry.github.io/r-novice-gapminder)
 
 ### Experienced R courses

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,8 +160,8 @@ markdown_extensions:
   - pymdownx.keys
   - md_in_html
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.tasklist:
       custom_checkbox: true
       


### PR DESCRIPTION
Fix WARNING/INFO messages when running `mkdocs`.

* Handle deprecation warnings - change `materialx.emoji` to `material.extensions.emoji`
* Fix broken links

With this PR these are no longer logged:
```
$ mkdocs serve
INFO    -  DeprecationWarning: 'materialx.emoji.twemoji' is deprecated.
           Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           instead of 'materialx.emoji.twemoji' in your 'mkdocs.yml' file.

           ```
           markdown_extensions:
             - pymdownx.emoji:
                 emoji_index: !!python/name:material.extensions.emoji.twemoji
                 emoji_generator: !!python/name:material.extensions.emoji.to_svg
           ```

           'mkdocs_material_extensions' is deprecated and will no longer be
           supported moving forward. This is the last release.

             File "/venv/lib/python3.10/site-packages/materialx/emoji.py", line 118, in twemoji
               return _patch_index(options)
             File "/venv/lib/python3.10/site-packages/materialx/emoji.py", line 68, in _deprecated_func
               warnings.warn(
WARNING -  Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           instead of 'materialx.emoji.twemoji' in your 'mkdocs.yml' file.

           ```
           markdown_extensions:
             - pymdownx.emoji:
                 emoji_index: !!python/name:material.extensions.emoji.twemoji
                 emoji_generator: !!python/name:material.extensions.emoji.to_svg
           ```

           'mkdocs_material_extensions' is deprecated and will no longer be
           supported moving forward. This is the last release.

...

INFO    -  DeprecationWarning: 'materialx.emoji.to_svg' is deprecated.
           Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.to_svg'
           instead of 'materialx.emoji.to_svg' in your 'mkdocs.yml' file.

           ```
           markdown_extensions:
             - pymdownx.emoji:
                 emoji_index: !!python/name:material.extensions.emoji.twemoji
                 emoji_generator: !!python/name:material.extensions.emoji.to_svg
           ```

           'mkdocs_material_extensions' is deprecated and will no longer be
           supported moving forward. This is the last release.

             File "/venv/lib/python3.10/site-packages/pymdownx/emoji.py", line 328, in handleMatch
               el = self.generator(
             File "/venv/lib/python3.10/site-packages/materialx/emoji.py", line 68, in _deprecated_func
               warnings.warn(
WARNING -  Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.to_svg'
           instead of 'materialx.emoji.to_svg' in your 'mkdocs.yml' file.

           ```
           markdown_extensions:
             - pymdownx.emoji:
                 emoji_index: !!python/name:material.extensions.emoji.twemoji
                 emoji_generator: !!python/name:material.extensions.emoji.to_svg
           ```

           'mkdocs_material_extensions' is deprecated and will no longer be
           supported moving forward. This is the last release.
INFO    -  Doc file 'software/python.md' contains an unrecognized relative link 'Python versions', it was left as is.
INFO    -  Doc file 'software/r.md' contains an unrecognized relative link 'swcarpentry.github.io/r-novice-inflammation/', it was left as is.
INFO    -  Doc file 'cluster_guides/start_interactive_node.md' contains a link '#when-to-use-an-interactive node', but there is no such anchor on this page.
INFO    -  Doc file 'software/beast2.md' contains a link '../getting_started/login_rackham.md#remote-desktop-via-a-ThinLinc client', but the doc
           'getting_started/login_rackham.md' does not contain an anchor '#remote-desktop-via-a-ThinLinc client'.
INFO    -  Doc file 'software/beast2.md' contains a link '../getting_started/login_rackham.md#remote-desktop-via-the-web', but the doc
           'getting_started/login_rackham.md' does not contain an anchor '#remote-desktop-via-the-web'.
INFO    -  Doc file 'software/install.md' contains a link 'compiling_parallel.md#overview-of-available-compilers-from-gcc-and-intel-and-compatible-mpi-libraries', but
           the doc 'software/compiling_parallel.md' does not contain an anchor '#overview-of-available-compilers-from-gcc-and-intel-and-compatible-mpi-libraries'.
INFO    -  Doc file 'software/jobstats.md' contains a link '#jobstats---plot', but there is no such anchor on this page.
INFO    -  Doc file 'software/python_venv.md' contains a link '../software/python.md#loading-python-modules', but the doc 'software/python.md' does not contain an
           anchor '#loading-python-modules'.
INFO    -  Documentation built in 6.60 seconds
```