### PR TITLE
update info on login node use for RStudio

### DIFF
--- a/docs/cluster_guides/login_node.md
+++ b/docs/cluster_guides/login_node.md
@@ -91,7 +91,7 @@ flowchart TD
 
     For example, when
     [using RStudio on Bianca](../software/rstudio_on_bianca.md)
-    it is recommended to use two nodes (but one node *does* work).
+    it is recommended to use at least two cores (and login node has 2 cores only).
 
     So, if you can, use the login node. If you need more resources,
     either use [the job scheduler](../cluster_guides/slurm.md) or


### PR DESCRIPTION
There is an inconsistency in our recommendations :  
We recommend using 2 nodes for RStudio here : https://docs.uppmax.uu.se/cluster_guides/login_node/
Here we recommend using 2 cores for RStudio: https://docs.uppmax.uu.se/software/rstudio_on_bianca/