### PR TITLE
Pelle hardware table changes

### DIFF
--- a/docs/hardware/clusters/pelle.md
+++ b/docs/hardware/clusters/pelle.md
@@ -1,11 +1,11 @@
 # Pelle/Maja hardware
 
-No of nodes     | CPUs                              | Cores<br/>Threads |  Memory   | Scratch | GPUs           | Name
---------------- | --------------------------------- | ----------------- | --------- |-------- |--------------- |------------
-116             |  AMD EPYC 9454P (Zen4)  2.75 GHz  | 48<br/>96         | 768 GiB   | 6? TB   | N/A            | p[1-115]
-2               |  AMD EPYC 9454P (Zen4)  2.75 GHz  | 48<br/>96         | 2 / 3 TiB | 6? TB   | N/A            | p[251-252]
-4               |  2 x AMD EPYC 9124 (Zen4)  3 GHz  | 2 x 16<br/>2 x 32 | 384 GiB   | 6? TB   | 10 x L40       | p[201-204]
-2               |  2 x AMD EPYC 9124 (Zen4)  3 GHz  | 2 x 16<br/>2 x 32 | 384 GiB   | 6? TB   | 2 x H100       | p[205-206]
+Nodes  | CPUs                              | Cores<br/>Threads | Memory    | Scratch | GPUs
+-------| --------------------------------- | ----------------- | --------- |-------- |----------
+115    |  AMD EPYC 9454P (Zen4)  2.75 GHz  | 48<br/>96         | 768 GiB   | 1.7 TiB | N/A
+2      |  AMD EPYC 9454P (Zen4)  2.75 GHz  | 48<br/>96         | 2 / 3 TiB | 6.9 TiB | N/A
+4      |  2 x AMD EPYC 9124 (Zen4)  3 GHz  | 2 x 16<br/>2 x 32 | 384 GiB   | 6.9 TiB | 10 x L40
+2      |  2 x AMD EPYC 9124 (Zen4)  3 GHz  | 2 x 16<br/>2 x 32 | 384 GiB   | 6.9 TiB | 2 x H100
 
 ## CPUs
 


### PR DESCRIPTION
Use non-breaking space to avoid browsers breaking lines in weird places.

Remove node names to make table smaller, this table is about hardware.

Fix regular node count.

Fix scratch disk space.