### PR TITLE
Fix troubleshooting typo and permissions

### DIFF
--- a/docs/software/ssh_key_use_pelle.md
+++ b/docs/software/ssh_key_use_pelle.md
@@ -109,15 +109,15 @@ Possible reason 2 is that the folders used by SSH do not have proper rights (fro
 To give the folders needed by SSH the proper rights, on Pelle, do:
 
 ```bash
-chmod 700 .ssh/authorised_keys
-chmod 700 .ssh
+chmod 600 ~/.ssh/authorized_keys
+chmod 700 ~/.ssh
 chmod 700 ~
 ```
 
 On your local computer, do:
 
 ```bash
-chmod 700 .ssh/authorised_keys
-chmod 700 .ssh
-chmod 700 ~
+chmod 600 ~/.ssh/id_ed25519_uppmax_login
+chmod 644 ~/.ssh/id_ed25519_uppmax_login.pub
+chmod 700 ~/.ssh
 ```


### PR DESCRIPTION
A typo in the troubleshooting section: authorised_keys should be authorized_keys, which is the filename used by OpenSSH.

Adjusted the suggested permissions based on the referenced website in the documentation. The authorized_keys file should use 600, the .ssh directory and the home directory should use 700.

Updated the local computer instructions, authorized_keys is used on Pelle, the relevant files on local computer are the private key and the public key